### PR TITLE
Clear VIP hash when deleting rejected payments

### DIFF
--- a/main.py
+++ b/main.py
@@ -2292,6 +2292,9 @@ async def clear_tx_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if p.status != "rejected":
             return await msg.reply_text("Apenas transações rejeitadas podem ser limpas.")
         try:
+            vm = s.query(VipMembership).filter(VipMembership.tx_hash == tx_hash).first()
+            if vm:
+                vm.tx_hash = None
             s.delete(p)
             s.commit()
             return await msg.reply_text("Registro removido.")


### PR DESCRIPTION
## Summary
- ensure `/clear_tx` also detaches the tx hash from any VIP membership before removing the payment record

## Testing
- `python - <<'PY'
import py_compile
py_compile.compile('main.py', cfile='/tmp/main.pyc')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68af6ce2a4248331af2db6f2fcde9cb4