### PR TITLE
Allow /clear_tx to delete transactions regardless of status

### DIFF
--- a/main.py
+++ b/main.py
@@ -2289,8 +2289,6 @@ async def clear_tx_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
         p = s.query(Payment).filter(Payment.tx_hash == tx_hash).first()
         if not p:
             return await msg.reply_text("Nenhum registro encontrado para essa hash.")
-        if p.status != "rejected":
-            return await msg.reply_text("Apenas transações rejeitadas podem ser limpas.")
         try:
             vm = s.query(VipMembership).filter(VipMembership.tx_hash == tx_hash).first()
             if vm:


### PR DESCRIPTION
## Summary
- permit `/clear_tx` to remove payment records and related VIP links even if the transaction isn't rejected

## Testing
- `python -m py_compile main.py`
- `pytest` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_68af6f158a1483318e7b5549f16e24c3