### PR TITLE
Add Etherscan payment verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ As seguintes redes EVM são utilizadas para verificar transações via API públ
 - Optimism
 - Gnosis
 - Celo
+
+## Integração com Etherscan
+
+Transações na rede Ethereum também podem ser verificadas por meio da API do [Etherscan](https://etherscan.io/). Defina `ETHERSCAN_API_KEY` no ambiente para habilitar a verificação de pagamentos via Etherscan.

--- a/config.py
+++ b/config.py
@@ -14,6 +14,7 @@ def _load_default_chain() -> Dict[str, str]:
         "token_contract": (os.getenv("TOKEN_CONTRACT", "").strip().lower() or None),
         "decimals": int(os.getenv("TOKEN_DECIMALS", "18")),
         "bscscan_api_key": os.getenv("BSCSCAN_API_KEY", "").strip(),
+        "etherscan_api_key": os.getenv("ETHERSCAN_API_KEY", "").strip(),
     }
 
 
@@ -29,8 +30,10 @@ def _load_chain(prefix: str) -> Dict[str, str]:
         "bscscan_api_key": os.getenv(
             f"{upp}_BSCSCAN_API_KEY", os.getenv("BSCSCAN_API_KEY", "")
         ).strip(),
+        "etherscan_api_key": os.getenv(
+            f"{upp}_ETHERSCAN_API_KEY", os.getenv("ETHERSCAN_API_KEY", "")
+        ).strip(),
     }
-    
 
 
 _chain_names = os.getenv("CHAINS")

--- a/main.py
+++ b/main.py
@@ -2116,6 +2116,107 @@ async def verify_tx_bscscan(cfg: Dict[str, Any], tx_hash: str) -> Dict[str, Any]
             res["reason"] = "Valor não corresponde a nenhum plano"
         return res
     
+
+async def verify_tx_etherscan(cfg: Dict[str, Any], tx_hash: str) -> Dict[str, Any]:
+    """Verifica transações (ETH ou ERC-20) usando apenas a API do Etherscan."""
+    api_key = cfg.get("etherscan_api_key")
+    if not api_key:
+        return {"ok": False, "reason": "ETHERSCAN_API_KEY não definido"}
+    wallet = (cfg.get("wallet_address") or "").lower()
+    base_url = "https://api.etherscan.io/api"
+    async with httpx.AsyncClient(timeout=10) as client:
+        params = {
+            "module": "proxy",
+            "action": "eth_getTransactionReceipt",
+            "txhash": tx_hash,
+            "apikey": api_key,
+        }
+        r = await client.get(base_url, params=params)
+        receipt = r.json().get("result")
+        if not receipt or receipt.get("status") != "0x1":
+            return {"ok": False, "reason": "Transação não confirmada/sucesso ainda"}
+        r_block = await client.get(
+            base_url, params={"module": "proxy", "action": "eth_blockNumber", "apikey": api_key}
+        )
+        current_block_hex = r_block.json().get("result")
+        confirmations = _hex_to_int(current_block_hex) - _hex_to_int(
+            receipt.get("blockNumber", "0x0")
+        )
+        if confirmations < MIN_CONFIRMATIONS:
+            return {
+                "ok": False,
+                "reason": f"Confirmações insuficientes ({confirmations}/{MIN_CONFIRMATIONS})",
+            }
+        logs = receipt.get("logs", [])
+        for lg in logs:
+            topics = [t.lower() for t in lg.get("topics", [])]
+            if not topics or topics[0] != TRANSFER_TOPIC or len(topics) < 3:
+                continue
+            to_addr = _topic_address(topics[2])
+            if wallet and to_addr != wallet:
+                continue
+            contract_addr = (lg.get("address") or "").lower()
+            amount_raw = _hex_to_int(lg.get("data"))
+            price_dec = await fetch_price_usd_for_contract(contract_addr)
+            if not price_dec:
+                return {"ok": False, "reason": "Falha ao obter cotação do ativo"}
+            price, decimals = price_dec
+            min_units = int(round(MIN_TOKEN_AMOUNT * (10 ** decimals)))
+            if amount_raw < min_units:
+                return {
+                    "ok": False,
+                    "reason": f"Quantidade de token abaixo do mínimo ({MIN_TOKEN_AMOUNT})",
+                }
+            amount_native = amount_raw / (10 ** decimals)
+            amount_usd = amount_native * price
+            plan_days = infer_plan_days(amount_usd=amount_usd)
+            res = {
+                "ok": True,
+                "type": "erc20",
+                "to": to_addr,
+                "amount_raw": amount_raw,
+                "contract": contract_addr,
+                "decimals": decimals,
+                "confirmations": confirmations,
+                "amount_usd": amount_usd,
+                "plan_days": plan_days,
+                "chain_name": cfg.get("chain_name"),
+            }
+            if plan_days is None:
+                res["reason"] = "Valor não corresponde a nenhum plano"
+            return res
+        r_tx = await client.get(
+            base_url,
+            params={"module": "proxy", "action": "eth_getTransactionByHash", "txhash": tx_hash, "apikey": api_key},
+        )
+        tx = r_tx.json().get("result")
+        if not tx:
+            return {"ok": False, "reason": "Transação não encontrada"}
+        to_addr = (tx.get("to") or "").lower()
+        if wallet and to_addr != wallet:
+            return {"ok": False, "reason": "Destinatário diferente da carteira configurada"}
+        value_wei = _hex_to_int(tx.get("value"))
+        price = await fetch_price_usd(cfg)
+        if price is None:
+            return {"ok": False, "reason": "Falha ao obter cotação do ativo"}
+        amount_native = value_wei / (10 ** 18)
+        amount_usd = amount_native * price
+        plan_days = infer_plan_days(amount_usd=amount_usd)
+        res = {
+            "ok": True,
+            "type": "native",
+            "from": (tx.get("from") or "").lower(),
+            "to": to_addr,
+            "amount_wei": value_wei,
+            "confirmations": confirmations,
+            "amount_usd": amount_usd,
+            "plan_days": plan_days,
+            "chain_name": cfg.get("chain_name"),
+        }
+        if plan_days is None:
+            res["reason"] = "Valor não corresponde a nenhum plano"
+        return res
+
 async def detect_chain_from_hash(tx_hash: str) -> Optional[str]:
     """Tenta identificar em qual cadeia a transação existe usando APIs públicas."""
     async with httpx.AsyncClient(timeout=10) as client:
@@ -2135,14 +2236,15 @@ async def detect_chain_from_hash(tx_hash: str) -> Optional[str]:
 
 async def verify_tx_any(tx_hash: str) -> Dict[str, Any]:
     for cfg in CHAIN_CONFIGS:
-        try:
-            res = await verify_tx_bscscan(cfg, tx_hash)
-        except Exception as e:
-            logging.warning("Erro verificando via BscScan: %s", e)
-            continue
-        if res.get("ok"):
-            return res
-    return {"ok": False, "reason": "Transação não encontrada na BscScan"}
+        for fn, label in ((verify_tx_bscscan, "BscScan"), (verify_tx_etherscan, "Etherscan")):
+            try:
+                res = await fn(cfg, tx_hash)
+            except Exception as e:
+                logging.warning("Erro verificando via %s: %s", label, e)
+                continue
+            if res.get("ok"):
+                return res
+    return {"ok": False, "reason": "Transação não encontrada nas APIs"}
 
 
 async def verify_tx_blockchair(tx_hash: str, slug: Optional[str] = None) -> Dict[str, Any]:

--- a/test_etherscan_verify.py
+++ b/test_etherscan_verify.py
@@ -1,0 +1,146 @@
+import os
+os.environ["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+import asyncio
+import importlib
+import httpx
+
+os.environ.setdefault("BOT_TOKEN", "123:ABC")
+os.environ.setdefault("DATABASE_URL", "sqlite:///test.db")
+os.environ.setdefault("WEBHOOK_URL", "http://localhost")
+
+import main
+importlib.reload(main)
+
+WALLET = "0x40ddbd27f878d07808339f9965f013f1cbc2f812"
+CONTRACT = "0x7130d2a12b9bcbfae4f2634d864a1ee1ce3ead9c"
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+        self.status_code = 200
+    def json(self):
+        return self._data
+    def raise_for_status(self):
+        pass
+
+class DummyClientToken:
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def get(self, url, params):
+        self.calls.append((url, params))
+        action = params.get("action")
+        if action == "eth_getTransactionReceipt":
+            return DummyResponse({
+                "result": {
+                    "status": "0x1",
+                    "blockNumber": "0x10",
+                    "logs": [
+                        {
+                            "address": CONTRACT,
+                            "topics": [
+                                main.TRANSFER_TOPIC,
+                                "0x" + "0"*64,
+                                "0x" + "0"*24 + WALLET[2:],
+                            ],
+                            "data": "0x5",
+                        }
+                    ],
+                }
+            })
+        if action == "eth_blockNumber":
+            return DummyResponse({"result": "0x20"})
+        if action == "eth_call":
+            return DummyResponse({"result": "0x0"})
+        return DummyResponse({})
+
+class DummyClientNative:
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def get(self, url, params):
+        self.calls.append((url, params))
+        action = params.get("action")
+        if action == "eth_getTransactionReceipt":
+            return DummyResponse({
+                "result": {
+                    "status": "0x1",
+                    "blockNumber": "0x10",
+                    "logs": [],
+                }
+            })
+        if action == "eth_blockNumber":
+            return DummyResponse({"result": "0x20"})
+        if action == "eth_getTransactionByHash":
+            return DummyResponse({
+                "result": {
+                    "to": WALLET,
+                    "from": "0x" + "1"*40,
+                    "value": hex(70),
+                }
+            })
+        return DummyResponse({})
+
+def test_verify_tx_etherscan_token(monkeypatch):
+    client = DummyClientToken()
+    monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=10: client)
+    async def fake_price(addr):
+        return (14.0, 0)
+    monkeypatch.setattr(main, "fetch_price_usd_for_contract", fake_price)
+    cfg = {
+        "wallet_address": WALLET,
+        "etherscan_api_key": "KEY",
+        "chain_name": "Ethereum",
+    }
+    tx_hash = "0x" + "1"*64
+    res = asyncio.run(main.verify_tx_etherscan(cfg, tx_hash))
+    assert res["ok"] is True
+    assert res["amount_usd"] == 70.0
+    assert res["plan_days"] == 90
+    actions = [p[1]["action"] for p in client.calls]
+    assert set(["eth_getTransactionReceipt", "eth_blockNumber"]).issubset(actions)
+
+def test_verify_tx_etherscan_native(monkeypatch):
+    client = DummyClientNative()
+    monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=10: client)
+    async def fake_native_price(cfg):
+        return 1e18
+    monkeypatch.setattr(main, "fetch_price_usd", fake_native_price)
+    cfg = {
+        "wallet_address": WALLET,
+        "etherscan_api_key": "KEY",
+        "chain_name": "Ethereum",
+    }
+    tx_hash = "0x" + "2"*64
+    res = asyncio.run(main.verify_tx_etherscan(cfg, tx_hash))
+    assert res["ok"] is True
+    assert res["amount_usd"] == 70.0
+    assert res["plan_days"] == 90
+    actions = [p[1]["action"] for p in client.calls]
+    assert set(["eth_getTransactionReceipt", "eth_blockNumber", "eth_getTransactionByHash"]).issubset(actions)
+
+def test_verify_tx_etherscan_token_below_min(monkeypatch):
+    client = DummyClientToken()
+    monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=10: client)
+
+    async def fake_price(addr):
+        return (14.0, 0)
+
+    monkeypatch.setattr(main, "fetch_price_usd_for_contract", fake_price)
+    monkeypatch.setattr(main, "MIN_TOKEN_AMOUNT", 10)
+
+    cfg = {
+        "wallet_address": WALLET,
+        "etherscan_api_key": "KEY",
+        "chain_name": "Ethereum",
+    }
+    tx_hash = "0x" + "1" * 64
+    res = asyncio.run(main.verify_tx_etherscan(cfg, tx_hash))
+    assert res["ok"] is False
+    assert "Quantidade de token abaixo do mínimo" in res["reason"]


### PR DESCRIPTION
## Summary
- support Etherscan API configuration for transaction checks
- verify Ethereum payments using Etherscan API
- document Etherscan integration and add tests

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b02d1ab91c8331a646af97282bb0c6