### PR TITLE
Add Blockscan transaction verification

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,14 +1,32 @@
 from dotenv import load_dotenv
 import os
-from typing import Dict, List
+from typing import Dict, List, Any
 
 load_dotenv()
 
 
-def _load_default_chain() -> Dict[str, str]:
+CHAIN_ID_MAP = {
+    "Ethereum": 1,
+    "Goerli": 5,
+    "Sepolia": 11155111,
+    "Binance Smart Chain": 56,
+    "Polygon": 137,
+    "Avalanche": 43114,
+    "Fantom": 250,
+    "Arbitrum": 42161,
+    "Optimism": 10,
+    "Base": 8453,
+}
+
+
+def _load_default_chain() -> Dict[str, Any]:
     """Fallback to legacy single-chain env variables."""
+    chain_name = os.getenv("CHAIN_NAME", "Polygon").strip()
+    chain_id_env = os.getenv("CHAIN_ID")
+    chain_id = int(chain_id_env) if chain_id_env else CHAIN_ID_MAP.get(chain_name, 0)
     return {
-        "chain_name": os.getenv("CHAIN_NAME", "Polygon").strip(),
+        "chain_name": chain_name,
+        "chain_id": chain_id,
         "rpc_url": os.getenv("RPC_URL", "").strip(),
         "wallet_address": (os.getenv("WALLET_ADDRESS", "").strip() or "").lower(),
         "token_contract": (os.getenv("TOKEN_CONTRACT", "").strip().lower() or None),
@@ -18,11 +36,15 @@ def _load_default_chain() -> Dict[str, str]:
     }
 
 
-def _load_chain(prefix: str) -> Dict[str, str]:
+def _load_chain(prefix: str) -> Dict[str, Any]:
     """Load chain configuration using a prefix (e.g., 'POLYGON')."""
     upp = prefix.upper()
+    chain_name = os.getenv(f"{upp}_CHAIN_NAME", prefix).strip()
+    chain_id_env = os.getenv(f"{upp}_CHAIN_ID")
+    chain_id = int(chain_id_env) if chain_id_env else CHAIN_ID_MAP.get(chain_name, 0)
     return {
-        "chain_name": os.getenv(f"{upp}_CHAIN_NAME", prefix).strip(),
+        "chain_name": chain_name,
+        "chain_id": chain_id,
         "rpc_url": os.getenv(f"{upp}_RPC_URL", "").strip(),
         "wallet_address": (os.getenv(f"{upp}_WALLET_ADDRESS", "").strip() or "").lower(),
         "token_contract": (os.getenv(f"{upp}_TOKEN_CONTRACT", "").strip().lower() or None),
@@ -39,6 +61,6 @@ def _load_chain(prefix: str) -> Dict[str, str]:
 _chain_names = os.getenv("CHAINS")
 if _chain_names:
     names = [n.strip() for n in _chain_names.split(",") if n.strip()]
-    CHAIN_CONFIGS: List[Dict[str, str]] = [_load_chain(name) for name in names]
+    CHAIN_CONFIGS: List[Dict[str, Any]] = [_load_chain(name) for name in names]
 else:
     CHAIN_CONFIGS = [_load_default_chain()]

--- a/test_blockscan_verify.py
+++ b/test_blockscan_verify.py
@@ -1,0 +1,152 @@
+import os
+os.environ["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+import asyncio
+import importlib
+import httpx
+
+os.environ.setdefault("BOT_TOKEN", "123:ABC")
+os.environ.setdefault("DATABASE_URL", "sqlite:///test.db")
+os.environ.setdefault("WEBHOOK_URL", "http://localhost")
+
+import main
+importlib.reload(main)
+
+WALLET = "0x40ddbd27f878d07808339f9965f013f1cbc2f812"
+CONTRACT = "0x7130d2a12b9bcbfae4f2634d864a1ee1ce3ead9c"
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+        self.status_code = 200
+    def json(self):
+        return self._data
+    def raise_for_status(self):
+        pass
+
+class DummyClientToken:
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def get(self, url, params):
+        self.calls.append((url, params))
+        action = params.get("action")
+        if action == "eth_getTransactionReceipt":
+            return DummyResponse({
+                "result": {
+                    "status": "0x1",
+                    "blockNumber": "0x10",
+                    "logs": [
+                        {
+                            "address": CONTRACT,
+                            "topics": [
+                                main.TRANSFER_TOPIC,
+                                "0x" + "0"*64,
+                                "0x" + "0"*24 + WALLET[2:],
+                            ],
+                            "data": "0x5",
+                        }
+                    ],
+                }
+            })
+        if action == "eth_blockNumber":
+            return DummyResponse({"result": "0x20"})
+        if action == "eth_call":
+            return DummyResponse({"result": "0x0"})
+        return DummyResponse({})
+
+class DummyClientNative:
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def get(self, url, params):
+        self.calls.append((url, params))
+        action = params.get("action")
+        if action == "eth_getTransactionReceipt":
+            return DummyResponse({
+                "result": {
+                    "status": "0x1",
+                    "blockNumber": "0x10",
+                    "logs": [],
+                }
+            })
+        if action == "eth_blockNumber":
+            return DummyResponse({"result": "0x20"})
+        if action == "eth_getTransactionByHash":
+            return DummyResponse({
+                "result": {
+                    "to": WALLET,
+                    "from": "0x" + "1"*40,
+                    "value": hex(70),
+                }
+            })
+        return DummyResponse({})
+
+def test_verify_tx_blockscan_token(monkeypatch):
+    client = DummyClientToken()
+    monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=10: client)
+    async def fake_price(addr):
+        return (14.0, 0)
+    monkeypatch.setattr(main, "fetch_price_usd_for_contract", fake_price)
+    cfg = {
+        "wallet_address": WALLET,
+        "etherscan_api_key": "KEY",
+        "chain_name": "Ethereum",
+        "chain_id": 1,
+    }
+    tx_hash = "0x" + "1"*64
+    res = asyncio.run(main.verify_tx_blockscan(cfg, tx_hash))
+    assert res["ok"] is True
+    assert res["amount_usd"] == 70.0
+    assert res["plan_days"] == 90
+    actions = [p[1]["action"] for p in client.calls]
+    assert set(["eth_getTransactionReceipt", "eth_blockNumber"]).issubset(actions)
+    for call in client.calls:
+        assert call[0] == "https://api.etherscan.io/v2/api"
+        assert call[1]["chainid"] == 1
+
+def test_verify_tx_blockscan_native(monkeypatch):
+    client = DummyClientNative()
+    monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=10: client)
+    async def fake_native_price(cfg):
+        return 1e18
+    monkeypatch.setattr(main, "fetch_price_usd", fake_native_price)
+    cfg = {
+        "wallet_address": WALLET,
+        "etherscan_api_key": "KEY",
+        "chain_name": "Ethereum",
+        "chain_id": 1,
+    }
+    tx_hash = "0x" + "2"*64
+    res = asyncio.run(main.verify_tx_blockscan(cfg, tx_hash))
+    assert res["ok"] is True
+    assert res["amount_usd"] == 70.0
+    assert res["plan_days"] == 90
+    actions = [p[1]["action"] for p in client.calls]
+    assert set(["eth_getTransactionReceipt", "eth_blockNumber", "eth_getTransactionByHash"]).issubset(actions)
+    for call in client.calls:
+        assert call[0] == "https://api.etherscan.io/v2/api"
+        assert call[1]["chainid"] == 1
+
+def test_verify_tx_blockscan_token_below_min(monkeypatch):
+    client = DummyClientToken()
+    monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=10: client)
+    async def fake_price(addr):
+        return (14.0, 0)
+    monkeypatch.setattr(main, "fetch_price_usd_for_contract", fake_price)
+    monkeypatch.setattr(main, "MIN_TOKEN_AMOUNT", 10)
+    cfg = {
+        "wallet_address": WALLET,
+        "etherscan_api_key": "KEY",
+        "chain_name": "Ethereum",
+        "chain_id": 1,
+    }
+    tx_hash = "0x" + "1" * 64
+    res = asyncio.run(main.verify_tx_blockscan(cfg, tx_hash))
+    assert res["ok"] is False
+    assert "Quantidade de token abaixo do mínimo" in res["reason"]


### PR DESCRIPTION
## Summary
- map chain configs to Etherscan v2 chain IDs
- add verify_tx_blockscan for unified Blockscan checks
- route verify_tx_any through Blockscan verification only

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b03345f9648331b59dd788c48f5a8d