### PR TITLE
feat: load chain data from Web3Auth

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,49 +2,42 @@ import os
 from typing import Dict, List, Any
 from dotenv import load_dotenv
 
+from web3auth_chains import load_web3auth_chains
+
 load_dotenv()
 
 
-CHAIN_ID_MAP = {
-    "Ethereum": 1,
-    "Goerli": 5,
-    "Sepolia": 11155111,
-    "Binance Smart Chain": 56,
-    "Polygon": 137,
-    "Avalanche": 43114,
-    "Fantom": 250,
-    "Arbitrum": 42161,
-    "Optimism": 10,
-    "Base": 8453,
-}
-
-# Mapping to infer the native token symbol for common chains. This is used as a
-# sensible default when the environment does not explicitly define one.
-CHAIN_SYMBOL_MAP = {
-    "Ethereum": "ETH",
-    "Goerli": "ETH",
-    "Sepolia": "ETH",
-    "Binance Smart Chain": "BNB",
-    "Polygon": "MATIC",
-    "Avalanche": "AVAX",
-    "Fantom": "FTM",
-    # Rollups and L2s currently use ETH as their native token
-    "Arbitrum": "ETH",
-    "Optimism": "ETH",
-    "Base": "ETH",
-}
+try:
+    _CHAIN_DATA = load_web3auth_chains()
+except Exception:
+    # Fallback to a minimal built-in dataset when the official list is
+    # unreachable. RPC URLs can still be overridden via environment
+    # variables.
+    _CHAIN_DATA = {
+        "Ethereum": {"chain_id": 1, "symbol": "ETH", "rpc": "https://rpc.ankr.com/eth"},
+        "Goerli": {"chain_id": 5, "symbol": "ETH", "rpc": "https://rpc.ankr.com/eth_goerli"},
+        "Sepolia": {"chain_id": 11155111, "symbol": "ETH", "rpc": "https://rpc.sepolia.org"},
+        "Binance Smart Chain": {"chain_id": 56, "symbol": "BNB", "rpc": "https://bsc-dataseed.binance.org"},
+        "Polygon": {"chain_id": 137, "symbol": "MATIC", "rpc": "https://polygon-rpc.com"},
+        "Avalanche": {"chain_id": 43114, "symbol": "AVAX", "rpc": "https://api.avax.network/ext/bc/C/rpc"},
+        "Fantom": {"chain_id": 250, "symbol": "FTM", "rpc": "https://rpc.ftm.tools"},
+        "Arbitrum": {"chain_id": 42161, "symbol": "ETH", "rpc": "https://arb1.arbitrum.io/rpc"},
+        "Optimism": {"chain_id": 10, "symbol": "ETH", "rpc": "https://mainnet.optimism.io"},
+        "Base": {"chain_id": 8453, "symbol": "ETH", "rpc": "https://mainnet.base.org"},
+    }
 
 
 def _load_default_chain() -> Dict[str, Any]:
     """Fallback to legacy single-chain env variables."""
     chain_name = os.getenv("CHAIN_NAME", "Polygon").strip()
+    info = _CHAIN_DATA.get(chain_name, {})
     chain_id_env = os.getenv("CHAIN_ID")
-    chain_id = int(chain_id_env) if chain_id_env else CHAIN_ID_MAP.get(chain_name, 0)
-    symbol = os.getenv("SYMBOL") or CHAIN_SYMBOL_MAP.get(chain_name, "")
+    chain_id = int(chain_id_env) if chain_id_env else info.get("chain_id", 0)
+    symbol = os.getenv("SYMBOL") or info.get("symbol", "")
     return {
         "chain_name": chain_name,
         "chain_id": chain_id,
-        "rpc_url": os.getenv("RPC_URL", "").strip(),
+        "rpc_url": os.getenv("RPC_URL", info.get("rpc", "")).strip(),
         "wallet_address": (os.getenv("WALLET_ADDRESS", "").strip() or "").lower(),
         "token_contract": (os.getenv("TOKEN_CONTRACT", "").strip().lower() or None),
         "decimals": int(os.getenv("TOKEN_DECIMALS", "18")),
@@ -58,13 +51,14 @@ def _load_chain(prefix: str) -> Dict[str, Any]:
     """Load chain configuration using a prefix (e.g., 'POLYGON')."""
     upp = prefix.upper()
     chain_name = os.getenv(f"{upp}_CHAIN_NAME", prefix).strip()
+    info = _CHAIN_DATA.get(chain_name, {})
     chain_id_env = os.getenv(f"{upp}_CHAIN_ID")
-    chain_id = int(chain_id_env) if chain_id_env else CHAIN_ID_MAP.get(chain_name, 0)
-    symbol = os.getenv(f"{upp}_SYMBOL") or CHAIN_SYMBOL_MAP.get(chain_name, "")
+    chain_id = int(chain_id_env) if chain_id_env else info.get("chain_id", 0)
+    symbol = os.getenv(f"{upp}_SYMBOL") or info.get("symbol", "")
     return {
         "chain_name": chain_name,
         "chain_id": chain_id,
-        "rpc_url": os.getenv(f"{upp}_RPC_URL", "").strip(),
+        "rpc_url": os.getenv(f"{upp}_RPC_URL", info.get("rpc", "")).strip(),
         "wallet_address": (os.getenv(f"{upp}_WALLET_ADDRESS", "").strip() or "").lower(),
         "token_contract": (os.getenv(f"{upp}_TOKEN_CONTRACT", "").strip().lower() or None),
         "decimals": int(os.getenv(f"{upp}_TOKEN_DECIMALS", "18")),

--- a/web3auth_chains.py
+++ b/web3auth_chains.py
@@ -1,0 +1,65 @@
+"""Utilities for loading chain data from Web3Auth."""
+from __future__ import annotations
+
+from typing import Dict, Any, Iterable
+
+import requests
+
+WEB3AUTH_CHAIN_URL = "https://rpc.web3auth.io/chain-config"
+
+
+def load_web3auth_chains() -> Dict[str, Dict[str, Any]]:
+    """Fetch the official Web3Auth chain configuration list.
+
+    Returns a mapping keyed by chain name. Each entry provides:
+    ``chain_id`` (int), ``symbol`` (str) and ``rpc`` (str) when
+    available. A :class:`RuntimeError` is raised if the download or
+    parsing fails.
+    """
+    try:
+        response = requests.get(WEB3AUTH_CHAIN_URL, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+    except Exception as exc:  # pragma: no cover - network failure path
+        raise RuntimeError("Failed to download Web3Auth chain list") from exc
+
+    chains: Dict[str, Dict[str, Any]] = {}
+
+    iterable: Iterable[Any]
+    if isinstance(data, list):
+        iterable = data
+    elif isinstance(data, dict):
+        if isinstance(data.get("chains"), list):
+            iterable = data["chains"]
+        elif isinstance(data.get("result"), dict):
+            iterable = data["result"].values()
+        else:
+            iterable = data.values()
+    else:
+        iterable = []
+
+    for item in iterable:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name") or item.get("chainName") or item.get("displayName")
+        if not name:
+            continue
+        chain_id = item.get("chainId") or item.get("chain_id")
+        if isinstance(chain_id, str):
+            try:
+                chain_id = int(chain_id, 0)
+            except ValueError:
+                continue
+        if not isinstance(chain_id, int):
+            continue
+        symbol = (
+            item.get("ticker")
+            or item.get("symbol")
+            or item.get("nativeCurrency", {}).get("symbol", "")
+        )
+        rpc = item.get("rpcTarget") or item.get("rpc") or item.get("rpcUrl") or ""
+        chains[name] = {"chain_id": chain_id, "symbol": symbol, "rpc": rpc}
+
+    if not chains:
+        raise RuntimeError("Web3Auth chain list empty or unrecognized format")
+    return chains


### PR DESCRIPTION
## Summary
- add utility to fetch official Web3Auth chain list
- generate chain defaults from fetched data and allow RPC env overrides

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'ContractName' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_68b5a2e483888331bb82e2c0193de2f9