### PR TITLE
Move optional web3auth to extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ Este repositório contém um bot de Telegram para gerenciamento de planos VIP.
 
 As dependências estão divididas em dois arquivos:
 
-- `requirements-core.txt` – bibliotecas essenciais para execução do bot.
-- `requirements-extras.txt` – integrações opcionais (Stripe, Google, Web3 etc.).
+- `requirements.txt` – bibliotecas essenciais para execução do bot.
+- `requirements-extras.txt` – integrações opcionais (Stripe, Google, Web3, Web3Auth etc.).
 
 Instale apenas o núcleo:
 
 ```bash
-pip install -r requirements-core.txt
+pip install -r requirements.txt
 ```
 
 Ou inclua também as dependências extras:
 
 ```bash
-pip install -r requirements-core.txt -r requirements-extras.txt
+pip install -r requirements.txt -r requirements-extras.txt
 ```
 
 ## Redes suportadas pelo Blockchair

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -4,6 +4,7 @@ google-auth
 google-auth-oauthlib
 web3==6.20.1
 eth-account>=0.10.0
+web3auth
 pytesseract
 pillow
 pdfminer.six

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ httpx
 psycopg2
 web3==6.20.1
 requests==2.32.5
-web3auth


### PR DESCRIPTION
## Summary
- remove `web3auth` from core requirements and move to optional extras
- document optional Web3Auth usage and keep eth-account constraint aligned

## Testing
- `pip install -r requirements.txt`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: assert elapsed < 0.35)*

------
https://chatgpt.com/codex/tasks/task_e_68b5aa6bc1608331b813e481f76750d5