### PR TITLE
feat: auto-discover supported chains

### DIFF
--- a/web3auth_provider.py
+++ b/web3auth_provider.py
@@ -19,13 +19,15 @@ INFURA_RPC = {
 }
 
 
-def get_provider(chain: str) -> Optional[Web3.HTTPProvider]:
+def get_provider(chain: str, rpc_url: str = "") -> Optional[Web3.HTTPProvider]:
     """Retorna um HTTPProvider autenticado via Web3Auth para a rede indicada.
 
-    Se o Web3Auth não estiver configurado ou ocorrer algum erro, retorna um
-    provider HTTP simples apontando para a URL configurada.
+    ``rpc_url`` pode ser usado para sobrescrever a URL padrão (por exemplo,
+    quando derivada dinamicamente de ``config.CHAIN_CONFIGS``). Se o Web3Auth
+    não estiver configurado ou ocorrer algum erro, retorna um provider HTTP
+    simples apontando para a URL configurada.
     """
-    url = (INFURA_RPC.get(chain) or "").strip()
+    url = (rpc_url or INFURA_RPC.get(chain) or "").strip()
     if not url:
         return None
 


### PR DESCRIPTION
## Summary
- derive supported EVM chains from configuration or Web3Auth list
- pass RPC URLs through Web3Auth provider for each network
- clarify environment overrides for chain discovery

## Testing
- `pip install httpx sqlalchemy web3` *(failed: Could not connect to proxy)*
- `pytest` *(failed: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68b5b079117c8331bb5dd723e689862b