### PR TITLE
chore: upgrade sqlalchemy for python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.110.0
 uvicorn==0.29.0
 python-dotenv==1.0.1
-sqlalchemy==2.0.29
+sqlalchemy>=2.0.31,<3.0
 apscheduler==3.10.4
 python-telegram-bot==22.3
 pytz==2024.1


### PR DESCRIPTION
## Summary
- upgrade SQLAlchemy requirement to a Python 3.13-compatible release

## Testing
- `python -m pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `uvicorn main:app --host 127.0.0.1 --port 8000` *(fails: command not found: uvicorn)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b2eb522083318471cecfb42ea33f