### PR TITLE
Add commands to simulate sending VIP or free packs

### DIFF
--- a/main.py
+++ b/main.py
@@ -664,6 +664,16 @@ async def send_next_pack_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE)
     await _send_pack(pack)
     await reply_with_retry(update.effective_message,("Pack enviado com sucesso"))
 
+
+async def simularvip_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    context.args = ["vip"]
+    await send_next_pack_cmd(update, context)
+
+
+async def simularfree_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    context.args = ["free"]
+    await send_next_pack_cmd(update, context)
+
 def _parse_hhmm(hhmm: str) -> Optional[dtime]:
     if not re.match(r"^\d{2}:\d{2}$", hhmm):
         return None
@@ -892,7 +902,8 @@ application.add_handler(CommandHandler("set_packvip", set_packvip_cmd))
 application.add_handler(CommandHandler("set_packfree", set_packfree_cmd))
 application.add_handler(CommandHandler("schedule_pack", schedule_pack_cmd))
 application.add_handler(CommandHandler("send_pack", send_pack_cmd))
-application.add_handler(CommandHandler("send_next", send_next_pack_cmd))
+application.add_handler(CommandHandler("simularvip", simularvip_cmd))
+application.add_handler(CommandHandler("simularfree", simularfree_cmd))
 application.add_handler(pack_conv_handler)
 application.add_error_handler(error_handler)
 


### PR DESCRIPTION
## Summary
- add simularvip_cmd and simularfree_cmd wrappers that call existing send_next_pack_cmd with fixed pack type
- register `/simularvip` and `/simularfree` commands and remove the old `/send_next` handler

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `python3 -m pip install pytest` *(fails: externally-managed-environment)*
- `python3 -m venv .venv && .venv/bin/pip install pytest` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b8888d0c848331a838fed756f941bb