### PR TITLE
fix: send next pack to correct group

### DIFF
--- a/main.py
+++ b/main.py
@@ -656,12 +656,14 @@ async def send_next_pack_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE)
     kind = context.args[0].lower() if context.args else "vip"
     if kind == "free":
         pack = await pack_get_next_free()
+        dest_group_id = GROUP_FREE_ID
     else:
         pack = await pack_get_next_vip()
+        dest_group_id = GROUP_VIP_ID
     if not pack:
         await reply_with_retry(update.effective_message,("Nenhum pack pendente"))
         return
-    await _send_pack(pack)
+    await _send_pack(pack, dest_group_id)
     await reply_with_retry(update.effective_message,("Pack enviado com sucesso"))
 
 


### PR DESCRIPTION
## Summary
- pass destination group ID to `_send_pack` in `send_next_pack_cmd`
- ensure manual pack command routes VIP or free packs to proper group

## Testing
- `python3 -m py_compile main.py`
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68b88fe031848331b3dfbf1e985f8dc0